### PR TITLE
Type Error: Cannot read property '0' during createTable() request

### DIFF
--- a/lib/dynode/client.js
+++ b/lib/dynode/client.js
@@ -204,12 +204,12 @@ Client.prototype._parseThroughputSchema = function(options) {
 
 Client.prototype._parseKeySchema = function(options) {
   var hashKeyName = Object.keys(options.hash)[0];
-  var hashKeyType = options.hash[hashKeyName].name[0].toUpperCase();
+  var hashKeyType = options.hash[hashKeyName][0].toUpperCase();
   var keySchema = {"HashKeyElement":{"AttributeName": hashKeyName, "AttributeType": hashKeyType}};
 
   if(options.range) {
     var rangeKeyName = Object.keys(options.range)[0];
-    var rangeKeyType = options.range[rangeKeyName].name[0].toUpperCase();
+    var rangeKeyType = options.range[rangeKeyName][0].toUpperCase();
     keySchema["RangeKeyElement"] = {"AttributeName":rangeKeyName,"AttributeType":rangeKeyType};
   };
 


### PR DESCRIPTION
Fixes "TypeError: Cannot read property '0' of undefined at Client._parseKeySchema (/home/wordspot/wsnode/node_modules/dynode/lib/dynode/client.js:207:56)" (and also line 212)

Incorrectly referenced hash[hashKeyName].name[0](.name causes the error; I can't tell why the tests pass)
