### PR TITLE
Use `toJSON` where available in preference to `toString`.

### DIFF
--- a/lib/dynode/types.js
+++ b/lib/dynode/types.js
@@ -76,6 +76,8 @@ function toString(value) {
     return value.map(toString);
   } else if(_.isNumber(value)) {
     return Number(value).toString();
+  } else if (value.toJSON) {
+    return value.toJSON();
   } else if(value.toString){
     return value.toString();
   } else {


### PR DESCRIPTION
This makes round-tripping dates to/from JSON much less confusing.
