### PR TITLE
fixes undefined meta.Attributes error inside updateItem

### DIFF
--- a/lib/dynode/client.js
+++ b/lib/dynode/client.js
@@ -60,7 +60,7 @@ Client.prototype.putItem = function(tableName, item, options, cb) {
     cb = options;
     options = {};
   }
-  
+
   var request = util.mixin({}, {TableName: tableName, Item: Types.stringify(item)}, options);
   this._request("PutItem", request, cb);
 };
@@ -73,10 +73,12 @@ Client.prototype.updateItem = function(tableName, keys, item, options, cb) {
   }
 
   var request = util.mixin({}, {TableName: tableName, Key: Types.toKeys(keys), AttributeUpdates: Types.updateAttributes(item)}, options);
-  
+
   this._request("UpdateItem", request, function (err, meta) {
+    if (err) return cb(err);
+
     if (meta.Attributes) meta.Attributes = Types.parse(meta.Attributes);
-    
+
     cb(err, meta);
   });
 };
@@ -147,18 +149,18 @@ Client.prototype.scan = function(tableName, options, cb) {
 };
 
 Client.prototype.batchGetItem = function(options, cb) {
-  
+
   var request = _.reduce(options, function(memo, opt, table) {
     var attrs = {Keys : _.map(opt.keys, Types.toKeys) };
     if(opt.AttributesToGet) attrs.AttributesToGet = opt.AttributesToGet;
-    
+
     memo[table] = attrs;
     return memo;
   }, {});
 
   this._request("BatchGetItem", {RequestItems: request}, function(err, resp){
     if(err) return cb(err);
-    
+
     var responses = {};
     var meta = {UnprocessedKeys: resp.UnprocessedKeys, ConsumedCapacityUnits: {}};
     for (var table in resp.Responses) {
@@ -166,14 +168,14 @@ Client.prototype.batchGetItem = function(options, cb) {
       responses[table] = resp.Responses[table].Items.map(Types.parse)
     }
     return cb(null, responses, meta);
-  });      
+  });
 };
 
 Client.prototype._request = function(action, options, cb) {
   var self = this;
 
   var operation = retry.operation({retries: 10, factor: 2, minTimeout: 50});
-  
+
   operation.attempt(function(currentAttempt) {
     self.request.send(action, options, function(err, resp) {
       if(err && err.retry && operation.retry(err)) return; // check to see if should retry request

--- a/test/unit/client-test.js
+++ b/test/unit/client-test.js
@@ -61,8 +61,8 @@ describe("DynamoDB Client unit tests", function(){
 
       client.describeTable("TestTable", done);
     });
-  });  
-  
+  });
+
   describe("List Tables", function() {
     it('should make request to list all tables', function(done) {
       client._request = function(action, options, cb) {
@@ -78,7 +78,7 @@ describe("DynamoDB Client unit tests", function(){
       client._request = function(action, options, cb) {
         action.should.equal("ListTables");
         options.should.eql({Limit: 4, ExclusiveStartTableName: "SomeTable"});
-        
+
         cb();
       };
 
@@ -112,7 +112,6 @@ describe("DynamoDB Client unit tests", function(){
 
       client.updateTable("UpdateThisTable",  {read: 5, write: 2}, done);
     });
-
   });
 
   describe("Put Item", function() {
@@ -136,10 +135,10 @@ describe("DynamoDB Client unit tests", function(){
       client._request = function(action, options, cb) {
         action.should.equal("PutItem");
         options.TableName.should.equal("TestTable");
-        
+
         options.Item.should.eql({
           id    : { N: '99' },
-          nums  : { NS: ['22', '33', '44']}, 
+          nums  : { NS: ['22', '33', '44']},
           terms : { SS: ["foo", "bar", "baz"]}
         });
 
@@ -157,7 +156,7 @@ describe("DynamoDB Client unit tests", function(){
         options.TableName.should.equal("TestTable");
         options.ReturnValues.should.equal("ALL_OLD");
         options.Item.should.eql({id: { S: 'blah' }});
-        
+
         cb();
       };
 
@@ -205,7 +204,7 @@ describe("DynamoDB Client unit tests", function(){
         action.should.equal("UpdateItem");
         options.TableName.should.equal("TestTable");
         options.Expected.should.eql({"foo":{"Value":{"S":"bar"}}});
-        
+
         cb(null, {ConsumedCapacityUnits: 1});
       };
 
@@ -215,8 +214,8 @@ describe("DynamoDB Client unit tests", function(){
     it('should parse returned Attributes to json', function(done) {
       var updates = {age : 22};
 
-      client._request = function(action, options, cb) {        
-        cb(null, {ConsumedCapacityUnits: 1, 
+      client._request = function(action, options, cb) {
+        cb(null, {ConsumedCapacityUnits: 1,
                   Attributes : {
                     name : {"S":"Bob"}, age : {"N":"22"}
                   }
@@ -226,8 +225,26 @@ describe("DynamoDB Client unit tests", function(){
       client.updateItem("TestTable", "somekey" , updates, function(err, meta){
         meta.Attributes.name.should.equal("Bob");
         meta.Attributes.age.should.equal(22);
-        
-        done();  
+
+        done();
+      });
+
+    });
+
+	it('should handle errors from client._request', function(done) {
+      var updates = { friends : ["paul", "john", "ringo", "george", "paul"] };
+	  var awsError = new Error("One or more parameter values were invalid: Input collection friends contains duplicates.");
+
+      client._request = function(action, options, cb) {
+        cb(awsError);
+      };
+
+      client.updateItem("TestTable", "somekey" , updates, function(err, meta) {
+        should.not.exist(meta);
+        should.exist(err);
+        err.should.equal(awsError);
+
+        done();
       });
 
     });
@@ -346,7 +363,7 @@ describe("DynamoDB Client unit tests", function(){
         options.TableName.should.eql("QueryTable");
         options.RangeKeyCondition.should.eql({"AttributeValueList":[{"N":"AttributeValue2"}],"ComparisonOperator":"GT"});
         options.Limit.should.equal(13);
-        
+
         cb();
       };
 
@@ -431,7 +448,7 @@ describe("DynamoDB Client unit tests", function(){
 
     it("should parse returned response to json", function(done){
       var response = {
-        Responses :{ 
+        Responses :{
           Table1 : {
             Items:[
               {"name": {"S":"Bob"},"Age": {"N":"22"} },


### PR DESCRIPTION
when _request receives an error from send callback it does not pass a meta object.

updateItem first checks the meta object.  instead checks for error.  if error callback immediately.

adds unit test
