### PR TITLE
empty values should be deleted

### DIFF
--- a/lib/dynode/types.js
+++ b/lib/dynode/types.js
@@ -39,7 +39,7 @@ exports.updateAttributes = function(attrs) {
   
   var result = _.reduce(attrs, function(memo, value, key, obj) {
     var attr = {};
-    if(!_.isUndefined(value) && !_.isNull(value) && !isEmptyArray(value)) {
+    if(value !== "" && !_.isUndefined(value) && !_.isNull(value) && !isEmptyArray(value)) {
 
       if(Object.prototype.toString.call(value) === '[object Object]') {
         var action = Object.keys(value)[0];
@@ -53,11 +53,13 @@ exports.updateAttributes = function(attrs) {
         attr.Value[typeIndicator(value)] = toString(value);
         attr.Action = 'PUT';  
       }
-      
-      memo[key] = attr;
-
-      return memo;
+    } else {
+    	attr.Action = 'DELETE';
     }
+    
+    memo[key] = attr;
+
+    return memo;    
   },{});
   
   return result;


### PR DESCRIPTION
if value is an empty string, empty array, null
we should update the action to delete so that the value can be cleared.

i added the check for empty string because you expect the same behavior if we passed an empty array.

the only other option is to throw an error, but I think the use case is that the client code is requesting to clear that value, so the types module should auto set the action to delete for these values.
