### PR TITLE
Fixing `AmazonError` names.

### DIFF
--- a/lib/dynode/amazon-error.js
+++ b/lib/dynode/amazon-error.js
@@ -1,8 +1,6 @@
 var util = require('util');
 
-var AmazonError = function(options) {
-  this.name = 'AmazonError';
-
+function AmazonError(options) {
   if(options.type) {
     var split = options.type.split("#");
 
@@ -23,6 +21,8 @@ var AmazonError = function(options) {
 };
 
 util.inherits(AmazonError, Error);
+
+AmazonError.prototype.name = 'AmazonError';
 
 AmazonError.prototype.toString = function() {
   return util.format('%s - %s %d %s: %s', this.name, this.action, this.statusCode, this.type, this.message);


### PR DESCRIPTION
Now `AmazonError.name` is `"AmazonError"` instead of `undefined`, and the name is available on the prototype instead of set on each instance.
