### PR TITLE
Fix for: boolean values converted to strings instead of numbers

### DIFF
--- a/lib/dynode/types.js
+++ b/lib/dynode/types.js
@@ -27,7 +27,7 @@ exports.parse = function(attrs) {
 
 // Convert to DynamoDB keys
 exports.toKeys = function(keys) {
-  if(_.isNumber(keys) || _.isString(keys)) {
+  if(_.isNumber(keys) || _.isBoolean(keys) || _.isString(keys)) {
     return exports.stringify({"HashKeyElement" : keys});
   } else if (keys.hash) {
     return exports.stringify({"HashKeyElement" : keys.hash, "RangeKeyElement" : keys.range});
@@ -75,14 +75,14 @@ function typeIndicator(value) {
   if(_.isArray(value)) {
     return typeIndicator(_.first(value))+ "S";
   } else {
-    return _.isNumber(value) ? "N" : "S";
+    return _.isNumber(value) || _.isBoolean(value) ? "N" : "S";
   }
 };
 
 function toString(value) {
   if(_.isArray(value)) {
     return value.map(toString);
-  } else if(_.isNumber(value)) {
+  } else if(_.isNumber(value) || _.isBoolean(value)) {
     return Number(value).toString();
   } else if (value.toJSON) {
     return value.toJSON();

--- a/test/unit/types-test.js
+++ b/test/unit/types-test.js
@@ -18,6 +18,12 @@ describe('Types', function() {
       converted.should.eql({"foo":{"N":"123"}});
     });
 
+    it("converts boolean attribute", function() {
+      var converted = Types.stringify({foo : true});
+
+      converted.should.eql({"foo":{"N":"1"}});
+    });
+
     it("converts string array", function() {
       var converted = Types.stringify({foo : ["a", "b", "c"]});
 


### PR DESCRIPTION
Boolean values should be converted to numbers on DynamoDB, in this way we can have the following item with boolean properties:

```
var item = { hash: "whatever", isBetter: true, isWorse: false };
item.put();
```

And it can be retrieved and tested in the following way:

```
var item = table.get_item({hash: "whatever"});
item.isBetter == true; // true
item.isWorse == false; // true
```

Because in Javascript (and many other languages):

```
1 == true; // true
0 == false; // true
```
