### PR TITLE
Include Throttling errors in the potential retry list.

### DIFF
--- a/lib/dynode/amazon-error.js
+++ b/lib/dynode/amazon-error.js
@@ -14,7 +14,9 @@ function AmazonError(options) {
   this.action = options.action;
 
   this.__defineGetter__("retry", function() {
-    return this.statusCode == 500 || this.type === "ProvisionedThroughputExceededException";
+    return this.statusCode == 500 ||
+           this.type === "ProvisionedThroughputExceededException" ||
+           this.type === "Throttling";
   });
 
   Error.captureStackTrace(this, this.constructor);

--- a/test/unit/amazon-error-test.js
+++ b/test/unit/amazon-error-test.js
@@ -43,6 +43,12 @@ describe("Amazon Error Handling", function() {
       err.retry.should.be.true;
     });
 
+    it("should be true for a Throttling exception", function() {
+      var err = new AmazonError({statusCode: 400, type: "com.amazonaws.dynamodb.v20111205#Throttling"});
+
+      err.retry.should.be.true;
+    });
+
     it("should be true for a 500 error", function() {
       var err = new AmazonError({statusCode: 500, type: "com.amazonaws.dynamodb.v20111205#InternalFailureException"});
 


### PR DESCRIPTION
See https://forums.aws.amazon.com/thread.jspa?messageID=356370 for an explanation of the difference. We have seen it inside Dynode's STS.getSessionToken.
