### PR TITLE
Add support for temporary security tokens

### DIFF
--- a/lib/dynode/request.js
+++ b/lib/dynode/request.js
@@ -6,6 +6,9 @@ var http        = require("http"),
 var Request = exports.Request = function Request(config) {
   this.credentials = {accessKeyId: config.accessKeyId, secretAccessKey: config.secretAccessKey};
 
+  if ('securityToken' in config)
+    this.credentials.securityToken = config.securityToken;
+
   this.config = _.defaults(config, {
     prefix : "DynamoDB_20111205.",
     region: "us-east-1"
@@ -38,6 +41,9 @@ Request.prototype.send = function(action, messageBody, cb) {
   };
 
   headers.authorization = Signer.authorization(self.credentials, req, date, self.config.region);
+
+  if ('securityToken' in self.credentials)
+    headers["x-amz-security-token"] = self.credentials.securityToken;
 
   var opts = {
     method : req.method,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "devDependencies": {
     "mocha" : "1.3.x",
-    "chai": "1.1.x"
+    "chai": "1.1.x",
+    "awssum": "0.12.x"
   },
   "scripts": {
     "test"  : "make test"


### PR DESCRIPTION
As an example of why this is necessary, an EC2 instance may be associated with an IAM role. The instance would then retrieve temporary security credentials from the instance metadata service. These credentials include a temporary security token that must be included in request headers.
