### PR TITLE
Bump version number so code with AWS token support can be identified in `npm` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dynode",
   "description": "node.js client for Amazon's DynamoDB",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": "Ryan Fitzgerald <ryan@codebrewstudios.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Not sure if the lack of session token support in the `npm` published version is intentional. But suggest that at least the version be updated after some recent commits for AWS session/temp credential support, so it's clear if `dynode` has AWS token support.

Looking at the commits, seems the AWS token changes did not also bump the `package.json` version. 
